### PR TITLE
Create install dir on the fly

### DIFF
--- a/logicmonitor_core/Collector.py
+++ b/logicmonitor_core/Collector.py
@@ -87,7 +87,8 @@ class Collector(LogicMonitor):
 
             if not os.path.exists(self.installdir):
                 os.makedirs(self.installdir)
-                logging.debug("Created installdir at `{dir}`".format(dir=self.installdir))
+                logging.debug("Created installdir at " +
+                              self.installdir)
 
             installfilepath = (self.installdir +
                                "/logicmonitorsetup" +

--- a/logicmonitor_core/Collector.py
+++ b/logicmonitor_core/Collector.py
@@ -85,6 +85,10 @@ class Collector(LogicMonitor):
             logging.debug("Platform is Linux")
             logging.debug("Agent ID is " + str(self.id))
 
+            if not os.path.exists(self.installdir):
+                os.makedirs(self.installdir)
+                logging.debug("Created installdir at `{dir}`".format(dir=self.installdir))
+
             installfilepath = (self.installdir +
                                "/logicmonitorsetup" +
                                str(self.id) + "_" + str(arch) +


### PR DESCRIPTION
In this PR, we fix the assumption that the collector install dir `/usr/local/logicmonitor` already exists before downloading the collector binary by creating the dir(s) if it does not already exist. 
